### PR TITLE
Update `jest-preset-stylelint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "jest": "^27.4.7",
     "eslint": "^8.6.0",
-    "jest-preset-stylelint": "^4.2.0"
+    "jest-preset-stylelint": "^6.3.2"
   },
   "dependencies": {
     "lodash.find": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,10 +2295,10 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
-jest-preset-stylelint@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/jest-preset-stylelint/-/jest-preset-stylelint-4.2.0.tgz#b1efe821bf525e5fd364e4ac3416d381391d13c9"
-  integrity sha512-BzkoD/qyB5dsTOAMTC1YR0ii4iJvqg2KFXXUl6qjoeyODAAYzYEw1xAHxvCG8fvep2rKemMgfP0FTKVzAruDRQ==
+jest-preset-stylelint@^6.3.2:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/jest-preset-stylelint/-/jest-preset-stylelint-6.3.2.tgz#90dbe3dda56a2ee3562cebb49dd8614d44f3056e"
+  integrity sha512-OnodJG8lMAzvhx5WjcGdne6TnGSWASlcUySd3sY+4E3Adgv4LcxBaNT6E15u5WTPpDsElaJqYNveANf2htR/Ng==
 
 jest-regex-util@^27.4.0:
   version "27.4.0"


### PR DESCRIPTION
Hi 👋,

I am one of the maintainers of Stylelint and we recently started [testing the latest and upcoming releases of Stylelint against various plugins and shared configs](https://github.com/stylelint/stylelint-ecosystem-tester).

Updating `jest-preset-stylelint` to the last version in the `v6` range was sufficient in my tests.